### PR TITLE
Move nim build flags to a new project-side nim.cfg

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -27,6 +27,6 @@ if "espressif" in env.subst("$PIOPLATFORM"):
 
 flags = f"--path:{libdeps} " f"--cpu:{cpu} "
 
-result = system(f"nim cpp {flags} {src/'main'}")
+result = system(f"nim cpp {flags} {prj_src_dir / 'main'}")
 if result != 0:
     exit(result)

--- a/compile.py
+++ b/compile.py
@@ -1,33 +1,32 @@
-from os import system, path
+from os import makedirs, system, path
 from shutil import copyfile
 from pathlib import Path
 
 Import("env")
 
-src = Path(env.subst("$PROJECT_SRC_DIR"))
+prj_dir = Path(env.subst("$PROJECT_DIR"))
+prj_src_dir = Path(env.subst("$PROJECT_SRC_DIR"))
 
-if not path.exists(src/'panicoverride.nim'):
-  copyfile(Path().parent/'panicoverride.nim', src/'panicoverride.nim')
+files_to_copy = (
+    ("nim.cfg", prj_dir),
+    ("panicoverride.nim", prj_src_dir),
+)
+
+# Copy a file if it is missing, making the directory if necessary
+for fn, dest in files_to_copy:
+    if not path.exists(dest):
+        makedirs(dest)
+    if not path.exists(dest / fn):
+        copyfile(Path().parent / fn, dest / fn)
 
 libdeps = env.subst("$PROJECT_LIBDEPS_DIR/$PIOENV")
 
 cpu = "avr"
 if "espressif" in env.subst("$PIOPLATFORM"):
-  cpu = "esp"
+    cpu = "esp"
 
-flags = (
-  f"--path:{libdeps} "
-  f"--nimcache:{src/'nimcache'} "
-  "--compileOnly "
-  f"--cpu:{cpu} "
-  "--deadCodeElim "
-  "--os:standalone "
-  "--noMain "
-  "--gc:none "
-  "--stacktrace:off "
-  "--profiler:off"
-)
+flags = f"--path:{libdeps} " f"--cpu:{cpu} "
 
 result = system(f"nim cpp {flags} {src/'main'}")
 if result != 0:
-  exit(result)
+    exit(result)

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,0 +1,17 @@
+nimcache:"src/nimcache"
+os:standalone
+mm:arc
+opt:size
+checks:off
+compileOnly:on
+panics:on
+profiler:off
+assertions:off
+stackTrace:off
+lineTrace:off
+exceptions:goto
+define:danger
+define:nimAllocPagesViaMalloc
+define:nimMemAlignTiny
+define:nimPage512
+define:noSignalHandler


### PR DESCRIPTION
Previously, the nim compiler build flags were in the Python script. Since command-line settings take priority over configuration file settings, this tool would override a user's build configuration.  We should avoid this.

This commit moves the build flags to a new nim.cfg file that gets copied to the user's project folder.  This allows the user to change the build settings as needed.
Added the "opt:size" build flag to nim.cfg.

There remain two flags that are set by this tool: path and cpu because they come from the platformio values in the Python script.